### PR TITLE
Manage MCP server output streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A plugin for the [LLM](https://llm.datasette.io/) command-line tool that enables
 - **Automatic Tool Discovery**: Automatically converts MCP tools into callable methods
 - **Resource & Prompt Access**: Expose MCP resources and prompts through the toolbox
 - **Configuration-Driven**: Easy setup for different MCP servers via configuration files
+- **STDERR Handling**: Control how MCP server error output is handled (disable, redirect to file, or display in terminal)
 
 ## Installation
 

--- a/STDERR_HANDLING.md
+++ b/STDERR_HANDLING.md
@@ -1,0 +1,208 @@
+# STDERR Handling for MCP Servers
+
+This document describes the STDERR handling functionality that allows you to control how standard error output from MCP servers is managed.
+
+## Overview
+
+When running MCP servers in stdio mode, the server process may write error messages, debug information, or other diagnostic output to STDERR. By default, this output is displayed directly in the terminal, which can be disruptive or unwanted. The STDERR handling feature provides three options for managing this output:
+
+1. **Disable** - Silence STDERR completely (default)
+2. **File** - Redirect STDERR to a specified file
+3. **Terminal** - Display STDERR in the terminal (original behavior)
+
+## Configuration Options
+
+The following new configuration options are available in `MCPServerConfig`:
+
+### `stderr_mode`
+- **Type**: `"disable" | "file" | "terminal"`
+- **Default**: `"disable"`
+- **Description**: How to handle STDERR output from the MCP server
+
+### `stderr_file`
+- **Type**: `string | null`
+- **Default**: `null`
+- **Description**: File path to redirect STDERR to (only used when `stderr_mode="file"`)
+
+### `stderr_append`
+- **Type**: `boolean`
+- **Default**: `false`
+- **Description**: Whether to append to the stderr file (true) or overwrite it (false)
+
+## Usage Examples
+
+### 1. Disable STDERR (Default)
+
+```json
+{
+  "servers": {
+    "my-server": {
+      "transport": "stdio",
+      "command": "python",
+      "args": ["/path/to/server.py"],
+      "stderr_mode": "disable"
+    }
+  }
+}
+```
+
+This is the default behavior. All STDERR output from the server is discarded.
+
+### 2. Redirect STDERR to File
+
+```json
+{
+  "servers": {
+    "my-server": {
+      "transport": "stdio",
+      "command": "python",
+      "args": ["/path/to/server.py"],
+      "stderr_mode": "file",
+      "stderr_file": "~/.logs/mcp_server_errors.log",
+      "stderr_append": true
+    }
+  }
+}
+```
+
+This redirects all STDERR output to the specified file. The file will be created if it doesn't exist, including any necessary parent directories.
+
+### 3. Display STDERR in Terminal
+
+```json
+{
+  "servers": {
+    "my-server": {
+      "transport": "stdio",
+      "command": "python", 
+      "args": ["/path/to/server.py"],
+      "stderr_mode": "terminal"
+    }
+  }
+}
+```
+
+This displays STDERR output in the terminal, which is useful for debugging.
+
+## Programmatic Usage
+
+You can also configure STDERR handling programmatically:
+
+```python
+from llm_mcp_plugin.config import MCPServerConfig
+from llm_mcp_plugin.mcp_client import MCPClient
+
+# Configure server with STDERR to file
+config = MCPServerConfig(
+    name="my-server",
+    transport="stdio",
+    command="python",
+    args=["/path/to/server.py"],
+    stderr_mode="file",
+    stderr_file="/tmp/mcp_debug.log",
+    stderr_append=False
+)
+
+client = MCPClient(config)
+
+# Use the client normally - STDERR will be handled according to config
+async with client.connect() as session:
+    tools = await session.list_tools()
+    # ... use the tools
+```
+
+## Implementation Details
+
+### File Handling
+- When `stderr_mode="file"`, the specified file path is expanded (e.g., `~` becomes the home directory)
+- Parent directories are created automatically if they don't exist
+- The file is opened in append mode if `stderr_append=true`, otherwise in write mode (overwrite)
+- File handles are properly closed when the connection ends
+
+### Error Handling
+- If the stderr file cannot be opened (e.g., permission denied), STDERR is automatically disabled
+- Invalid `stderr_mode` values default to "disable" with a warning
+- Configuration validation ensures `stderr_file` is provided when `stderr_mode="file"`
+
+### Transport Support
+- STDERR handling only applies to stdio transport
+- SSE and HTTP transports are not affected by these settings
+
+## Common Use Cases
+
+### Development and Debugging
+```json
+{
+  "stderr_mode": "terminal",
+  "description": "See all debug output in terminal"
+}
+```
+
+### Production Logging
+```json
+{
+  "stderr_mode": "file",
+  "stderr_file": "/var/log/mcp/server.log",
+  "stderr_append": true,
+  "description": "Log errors for monitoring"
+}
+```
+
+### Clean Operation
+```json
+{
+  "stderr_mode": "disable",
+  "description": "Silent operation (default)"
+}
+```
+
+### Per-Session Debugging
+```json
+{
+  "stderr_mode": "file",
+  "stderr_file": "/tmp/mcp_debug_session.log",
+  "stderr_append": false,
+  "description": "Fresh log file for each session"
+}
+```
+
+## Testing
+
+A test script is provided in `test_stderr_handling.py` that demonstrates all three modes:
+
+```bash
+python test_stderr_handling.py
+```
+
+This script creates temporary MCP servers that write to STDERR and verifies that the output is handled correctly according to the configuration.
+
+## Troubleshooting
+
+### STDERR file not created
+- Check file permissions for the target directory
+- Ensure the parent directory exists or can be created
+- Verify the file path is valid
+
+### Permission denied errors
+- Make sure the process has write permissions to the target directory
+- Consider using a different location like `/tmp/` for testing
+
+### STDERR still appearing in terminal
+- Verify `stderr_mode` is set correctly
+- Check that the configuration is being loaded properly
+- Ensure you're not seeing STDOUT output instead of STDERR
+
+## Migration from Previous Versions
+
+If you're upgrading from a previous version:
+
+1. The default behavior is now to disable STDERR (previously it was shown in terminal)
+2. To maintain the old behavior, set `stderr_mode: "terminal"`
+3. Existing configurations without STDERR settings will use the new default (disable)
+
+## Limitations
+
+- Only available for stdio transport
+- File path expansion is basic (only `~` is supported)
+- No log rotation or size limits are implemented
+- STDERR and STDOUT cannot be combined into a single file

--- a/examples/stderr_handling_example.json
+++ b/examples/stderr_handling_example.json
@@ -1,0 +1,36 @@
+{
+  "servers": {
+    "example-server-disabled-stderr": {
+      "transport": "stdio",
+      "command": "python",
+      "args": ["/path/to/server.py"],
+      "stderr_mode": "disable",
+      "description": "Example server with STDERR disabled (default)"
+    },
+    "example-server-stderr-to-file": {
+      "transport": "stdio", 
+      "command": "python",
+      "args": ["/path/to/server.py"],
+      "stderr_mode": "file",
+      "stderr_file": "~/.logs/mcp_server_errors.log",
+      "stderr_append": true,
+      "description": "Example server with STDERR redirected to a log file"
+    },
+    "example-server-stderr-terminal": {
+      "transport": "stdio",
+      "command": "python", 
+      "args": ["/path/to/server.py"],
+      "stderr_mode": "terminal",
+      "description": "Example server with STDERR displayed in terminal"
+    },
+    "debug-server": {
+      "transport": "stdio",
+      "command": "python",
+      "args": ["/path/to/debug_server.py", "--debug"],
+      "stderr_mode": "file",
+      "stderr_file": "/tmp/mcp_debug.log",
+      "stderr_append": false,
+      "description": "Debug server with STDERR logged to temporary file (overwrite mode)"
+    }
+  }
+}

--- a/test_stderr_handling.py
+++ b/test_stderr_handling.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Test script to verify STDERR handling functionality for MCP servers."""
+
+import asyncio
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+
+from llm_mcp_plugin.config import MCPServerConfig
+from llm_mcp_plugin.mcp_client import MCPClient
+
+
+# Simple test server that writes to STDERR
+TEST_SERVER_SCRIPT = '''#!/usr/bin/env python3
+import sys
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("test-stderr-server")
+
+# Write some test messages to stderr
+print("This is a test STDERR message from MCP server", file=sys.stderr)
+print("Another STDERR line for testing", file=sys.stderr)
+
+@mcp.tool()
+def test_tool() -> str:
+    """A simple test tool that also writes to stderr."""
+    print("Tool execution STDERR message", file=sys.stderr)
+    return "Tool executed successfully"
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")
+'''
+
+
+async def test_stderr_disable():
+    """Test STDERR disabled mode."""
+    print("Testing STDERR disable mode...")
+    
+    # Create temporary server script
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+        f.write(TEST_SERVER_SCRIPT)
+        server_script = f.name
+    
+    try:
+        # Configure server with STDERR disabled
+        config = MCPServerConfig(
+            name="test-stderr-disable",
+            transport="stdio",
+            command="python",
+            args=[server_script],
+            stderr_mode="disable"
+        )
+        
+        client = MCPClient(config)
+        
+        # Connect and call a tool
+        async with client.connect() as session:
+            tools = await session.list_tools()
+            print(f"Found {len(tools)} tools")
+            
+            # Call the test tool
+            result = await session.call_tool("test_tool", {})
+            print(f"Tool result: {result.content}")
+        
+        print("✓ STDERR disable test completed - no stderr output should be visible")
+        
+    finally:
+        os.unlink(server_script)
+
+
+async def test_stderr_to_file():
+    """Test STDERR to file mode."""
+    print("\nTesting STDERR to file mode...")
+    
+    # Create temporary server script
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+        f.write(TEST_SERVER_SCRIPT)
+        server_script = f.name
+    
+    # Create temporary stderr file
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+        stderr_file = f.name
+    
+    try:
+        # Configure server with STDERR to file
+        config = MCPServerConfig(
+            name="test-stderr-file",
+            transport="stdio",
+            command="python",
+            args=[server_script],
+            stderr_mode="file",
+            stderr_file=stderr_file,
+            stderr_append=False
+        )
+        
+        client = MCPClient(config)
+        
+        # Connect and call a tool
+        async with client.connect() as session:
+            tools = await session.list_tools()
+            print(f"Found {len(tools)} tools")
+            
+            # Call the test tool
+            result = await session.call_tool("test_tool", {})
+            print(f"Tool result: {result.content}")
+        
+        # Check if stderr was written to file
+        if os.path.exists(stderr_file):
+            with open(stderr_file, 'r') as f:
+                stderr_content = f.read()
+            print(f"✓ STDERR file test completed")
+            print(f"STDERR content written to {stderr_file}:")
+            print(stderr_content)
+        else:
+            print("✗ STDERR file was not created")
+        
+    finally:
+        os.unlink(server_script)
+        if os.path.exists(stderr_file):
+            os.unlink(stderr_file)
+
+
+async def test_stderr_terminal():
+    """Test STDERR to terminal mode."""
+    print("\nTesting STDERR to terminal mode...")
+    
+    # Create temporary server script
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+        f.write(TEST_SERVER_SCRIPT)
+        server_script = f.name
+    
+    try:
+        # Configure server with STDERR to terminal
+        config = MCPServerConfig(
+            name="test-stderr-terminal",
+            transport="stdio",
+            command="python",
+            args=[server_script],
+            stderr_mode="terminal"
+        )
+        
+        client = MCPClient(config)
+        
+        print("You should see STDERR messages in the terminal below:")
+        
+        # Connect and call a tool
+        async with client.connect() as session:
+            tools = await session.list_tools()
+            print(f"Found {len(tools)} tools")
+            
+            # Call the test tool
+            result = await session.call_tool("test_tool", {})
+            print(f"Tool result: {result.content}")
+        
+        print("✓ STDERR terminal test completed - stderr should be visible above")
+        
+    finally:
+        os.unlink(server_script)
+
+
+async def test_config_validation():
+    """Test configuration validation."""
+    print("\nTesting configuration validation...")
+    
+    # Test invalid config - file mode without stderr_file
+    try:
+        config = MCPServerConfig(
+            name="test-invalid",
+            transport="stdio",
+            command="python",
+            args=["test.py"],
+            stderr_mode="file"
+            # Missing stderr_file
+        )
+        config.validate_config()
+        print("✗ Configuration validation failed - should have raised error")
+    except ValueError as e:
+        print(f"✓ Configuration validation working: {e}")
+    
+    # Test valid config
+    try:
+        config = MCPServerConfig(
+            name="test-valid",
+            transport="stdio",
+            command="python",
+            args=["test.py"],
+            stderr_mode="file",
+            stderr_file="/tmp/test.log"
+        )
+        config.validate_config()
+        print("✓ Valid configuration accepted")
+    except ValueError as e:
+        print(f"✗ Valid configuration rejected: {e}")
+
+
+async def main():
+    """Run all tests."""
+    print("=" * 50)
+    print("MCP STDERR Handling Tests")
+    print("=" * 50)
+    
+    await test_config_validation()
+    await test_stderr_disable()
+    await test_stderr_to_file()
+    await test_stderr_terminal()
+    
+    print("\n" + "=" * 50)
+    print("All tests completed!")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Add configurable STDERR handling for MCP servers to allow disabling, redirecting to a file, or displaying in the terminal.

This introduces `stderr_mode`, `stderr_file`, and `stderr_append` configuration options. The default behavior for STDERR is now `disable` to prevent unwanted output, a change from the previous behavior where it was displayed in the terminal.

---
<a href="https://cursor.com/background-agent?bcId=bc-b2377d44-6d60-47e0-9659-620e43602581">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b2377d44-6d60-47e0-9659-620e43602581">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>